### PR TITLE
Update README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,9 @@ func ModuleTrees() {
 		types := m.GetTypes()
 
 		jsonBytes, _ := json.Marshal(struct {
-			Module gosmi.Module
-			Nodes  []gosmi.Node
-			Types  []gosmi.Type
+			Module gosmi.SmiModule
+			Nodes  []gosmi.SmiNode
+			Types  []gosmi.SmiType
 		}{
 			Module: m,
 			Nodes:  nodes,


### PR DESCRIPTION
Within your `README.md` file, the example code contained an error;  nonexistent types were referenced during `json.Marshal`.

I fixed the errors:

```
  Module gosmi.Module
  Nodes  []gosmi.Node
  Types  []gosmi.Type
```

... became ...

```
  Module gosmi.SmiModule
  Nodes  []gosmi.SmiNode
  Types  []gosmi.SmiType
```

Take care
