### PR TITLE
Fixes linking pending objects

### DIFF
--- a/smi/internal/object.go
+++ b/smi/internal/object.go
@@ -190,7 +190,7 @@ func (x *ObjectMap) linkObject(oid parser.Oid, o *Object) {
 		subId := oid.SubIdentifiers[i]
 		if subId.Name != nil {
 			obj := o.Module.GetObject(*subId.Name)
-			if obj != nil {
+			if obj != nil && obj.Node != nil {
 				parentName = ""
 				parentNodePtr = obj.Node
 				continue


### PR DESCRIPTION
Module.GetObject() returns pending (empty) objects in some cases. So x.addPending() called later with empty parentName, and object node is never being linked.