### PR TITLE
Add GetNodeByOID which keeps index

### DIFF
--- a/node.go
+++ b/node.go
@@ -97,3 +97,12 @@ func GetNodeByOID(oid types.Oid) (node SmiNode, err error) {
 	}
 	return CreateNode(smiNode), nil
 }
+
+func GetNodeByOIDWithIndex(oid types.Oid) (node SmiNode, index []types.SmiSubId, err error) {
+	smiNode, index := smi.GetNodeByOIDWithIndex(oid)
+	if smiNode == nil {
+		err = fmt.Errorf("Could not find node for OID %s", oid)
+		return
+	}
+	return CreateNode(smiNode), index, nil
+}

--- a/smi/node.go
+++ b/smi/node.go
@@ -48,6 +48,25 @@ func GetNodeByOID(oid types.Oid) *types.SmiNode {
 	return nodePtr.FirstObject.GetSmiNode()
 }
 
+func GetNodeByOIDWithIndex(oid types.Oid) (*types.SmiNode, []types.SmiSubId) {
+	if len(oid) == 0 || internal.Root() == nil {
+		return nil, nil
+	}
+	var parentPtr, nodePtr *internal.Node = nil, internal.Root()
+	i := 0
+	for ; i < len(oid) && nodePtr != nil; i++ {
+		parentPtr, nodePtr = nodePtr, nodePtr.Children.Get(oid[i])
+	}
+	if nodePtr == nil {
+		nodePtr = parentPtr
+		i--
+	}
+	if nodePtr == nil || nodePtr.FirstObject == nil {
+		return nil, nil
+	}
+	return nodePtr.FirstObject.GetSmiNode(), oid[i:]
+}
+
 // SmiNode *smiGetFirstNode(SmiModule *smiModulePtr, SmiNodekind nodekind)
 func GetFirstNode(smiModulePtr *types.SmiModule, nodekind types.NodeKind) *types.SmiNode {
 	if smiModulePtr == nil {


### PR DESCRIPTION
This function looks up a node by oid and also returns the part of the oid that have not been used to look up the node.  The usecase for this are oids of fields in a table.  E.g.  `IF-MIB::ifDescr.4` (`.1.3.6.1.2.1.2.2.1.2.4`) will return the oid of `ifDescr` and a index of `4`.

This functionality is hard to just implement anywhere else as the code in `smi/node.go` interacts with `smi/internal`.  So this functionality is tied closely to gosmi and I can't just implement my own function for this in my own module.

I don't really like the function names and the signature, but I also don't have better ones.  I'll gladly change them upon suggestion.